### PR TITLE
dispatch manager queue processing refactor

### DIFF
--- a/classes/managers/TEALDispatchManager.m
+++ b/classes/managers/TEALDispatchManager.m
@@ -177,14 +177,20 @@
 
 - (BOOL) beginQueueTraversal {
 
-    if (!self.processingQueue && [self queuedDispatchCount]) {
+    NSUInteger queueCount = [self queuedDispatchCount];
+    if (!self.processingQueue && queueCount) {
 
-        self.processingQueue = [self.queuedDispatches copy];
-        NSUInteger count = [self.processingQueue count];
+        self.processingQueue = [TEALDataQueue new];
 
-        [self.queuedDispatches dequeueAllObjects];
-            
-        [self.delegate willRunDispatchQueueWithCount:count];
+        [self.queuedDispatches dequeueNumberOfObjects:queueCount
+                                            withBlock:^(id dequeuedObject) {
+                                                
+                                                [self.processingQueue enqueueObject:dequeuedObject];
+                                            }];
+        
+        NSUInteger processingCount = [self.processingQueue count];
+
+        [self.delegate willRunDispatchQueueWithCount:processingCount];
             
         return YES;
     }

--- a/classes/managers/TEALDispatchManager.m
+++ b/classes/managers/TEALDispatchManager.m
@@ -165,7 +165,7 @@
     if ([self.delegate shouldAttemptDispatch]) {
 
         if ([self beginQueueTraversal]) {
-            [self recusivelyDispatchWithCompletion:^{
+            [self recursivelyDispatchWithCompletion:^{
                 
                 [self endQueueTraversal];
             }];
@@ -197,7 +197,7 @@
     return NO;
 }
 
-- (void) recusivelyDispatchWithCompletion:(TEALVoidBlock)completion {
+- (void) recursivelyDispatchWithCompletion:(TEALVoidBlock)completion {
 
     if (!self.processingQueue) {
         if (completion) {
@@ -220,7 +220,7 @@
     TEALDispatchBlock dispatchCompletion = ^(TEALDispatchStatus status, TEALDispatch *resultDispatch, NSError *error) {
         
         if (status == TEALDispatchStatusSent) {
-            [weakSelf recusivelyDispatchWithCompletion:completion];
+            [weakSelf recursivelyDispatchWithCompletion:completion];
         } else {
             
             if (weakSelf.processingQueue) {


### PR DESCRIPTION
runDispatchQueue now moves existing queued dispatches to a procesing queue and process from there.  This leaves the dispatch queue free to accumulate more dispatches while it is processing and now dispatches will be lost.
Additionally this will prevent long queue processing as new dispatches come in while processing a batch.