### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ These public classes are for Tealium clients and prospects to quickly and more c
 
 ###Table of Contents###
 - [Requirements](#requirements)
-- [Cocoapods Integration](#cocoapod-integration)
+- [CocoaPods Integration](#cocoapod-integration)
 - [Manual Integration](#manual-integration)
 - [Swift Bridging](#swift-bridging)
 
@@ -15,7 +15,7 @@ These public classes are for Tealium clients and prospects to quickly and more c
 - Minimum target iOS Version 7.0+ 
 
 
-###Cocoapods Integration###
+###CocoaPods Integration###
 In your project's *podfile*, add the following line:
    
 ```ruby


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
